### PR TITLE
Add missing keys and new example to modelSpec

### DIFF
--- a/pages/docs/configuration/librechat_yaml/object_structure/model_specs.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/model_specs.mdx
@@ -149,7 +149,7 @@ preset:
 **Key:**
 <OptionTable
   options={[
-    ['model', 'String (nullable, optional)', 'The model to use for the preset. This has to correspond to a model configured under endpoints.', 'None'],
+    ['model', 'String (nullable)', 'The model to use for the preset. This has to correspond to a model configured under endpoints.', 'None'],
   ]}
 />
 

--- a/pages/docs/configuration/librechat_yaml/object_structure/model_specs.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/model_specs.mdx
@@ -127,23 +127,6 @@ Each spec object in the `list` can have the following settings:
 
 The preset field for a modelSpec list item is made up of a comprehensive configuration blueprint for AI models within the system. It is designed to specify the operational settings of AI models, tailoring their behavior, outputs, and interactions with other system components and endpoints.
 
-### modelLabel
-
-**Key:**
-<OptionTable
-  options={[
-    ['modelLabel', 'String (nullable, optional)', 'The label used to identify the model in user interfaces or logs. It provides a human-readable name for the model, which is displayed in the UI, as well as made aware to the AI.', 'None'],
-  ]}
-/>
-
-**Default:** `None`
-
-**Example:**
-```yaml filename="modelSpecs / list / {spec_item} / preset / modelLabel"
-preset:
-  modelLabel: "Customer Support Bot"
-```
-
 ### endpoint
 
 **Key:**
@@ -159,6 +142,40 @@ preset:
 ```yaml filename="modelSpecs / list / {spec_item} / preset / endpoint"
 preset:
   endpoint: "openAI"
+```
+
+### model
+
+**Key:**
+<OptionTable
+  options={[
+    ['model', 'String (nullable, optional)', 'The model to use for the preset. This has to correspond to a model configured under endpoints.', 'None'],
+  ]}
+/>
+
+**Default:** `None`
+
+**Example:**
+```yaml filename="modelSpecs / list / {spec_item} / preset / model"
+preset:
+  model: "gpt-4-turbo"
+```
+
+### modelLabel
+
+**Key:**
+<OptionTable
+  options={[
+    ['modelLabel', 'String (nullable, optional)', 'The label used to identify the model in user interfaces or logs. It provides a human-readable name for the model, which is displayed in the UI, as well as made aware to the AI.', 'None'],
+  ]}
+/>
+
+**Default:** `None`
+
+**Example:**
+```yaml filename="modelSpecs / list / {spec_item} / preset / modelLabel"
+preset:
+  modelLabel: "Customer Support Bot"
 ```
 
 ### greeting
@@ -219,7 +236,7 @@ preset:
 
 ### model_options
 
-> These settings control the stochastic nature and behavior of model responses, affecting creativity, relevance, and variability.
+> These settings control the stochastic nature and behavior of model responses, affecting creativity, relevance, and variability. Additionally it is possible to specify the number of tokens for the context and output windows.
 
 **Key:**
 <OptionTable
@@ -230,6 +247,8 @@ preset:
     ['frequency_penalty', 'Number (optional)', 'Penalty for repetition in model responses.', ''],
     ['presence_penalty', 'Number (optional)', 'Penalty for repetition in model responses.', ''],
     ['stop', 'Array of Strings (optional)', 'Stop tokens for model responses.', ''],
+    ['maxContextTokens', 'Number (optional)', 'The maximum number of context tokens to provide to the model.', 'This is useful when configuring custom or non-standard models, or when you want to limit the maximum context for this preset.'],
+    ['max_tokens', 'Number (optional)', 'The maximum number of output tokens to request from the model.', 'This is useful when configuring custom or non-standard models, e.g. phi-3.'],
   ]}
 />
 
@@ -238,6 +257,7 @@ preset:
 preset:
   temperature: 0.7
   top_p: 0.9
+  maxContextTokens: 4096
 ```
 
 ### resendFiles

--- a/pages/docs/configuration/librechat_yaml/object_structure/model_specs.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/model_specs.mdx
@@ -32,6 +32,7 @@ modelSpecs:
       label: "Meeting Notes Assistant (GPT4)"
       description: "Generate meeting notes by simply pasting in the transcript from a Teams recording."
       preset:
+        default: true
         endpoint: "azureOpenAI"
         model: "gpt-4-turbo-1106-preview"
         maxContextTokens: 128000 # Maximum context tokens

--- a/pages/docs/configuration/librechat_yaml/object_structure/model_specs.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/model_specs.mdx
@@ -14,7 +14,7 @@ There are 3 main fields under `modelSpecs`:
 
 - If `enforce` is set to true, model specifications can potentially conflict with other interface settings such as `endpointsMenu`, `modelSelect`, `presets`, and `parameters`.
 - The `list` array contains detailed configurations for each model, including presets that dictate specific behaviors, appearances, and capabilities.
-- If interface fields are not specified, having a list of model specs will disable the following interface elements:
+- If [interface](interface.mdx) fields are not specified in the configuration, having a list of model specs will disable the following interface elements:
     - `endpointsMenu`
     - `modelSelect`
     - `parameters`
@@ -28,11 +28,34 @@ modelSpecs:
   enforce: true
   prioritize: true
   list:
-    - name: "commander_01"
-      label: "Commander in Chief"
-      description: "An AI roleplaying as the 50th President."
-      iconURL: "https://example.com/icon.jpg"
-      preset: {Refer to the detailed preset configuration example below}
+    - name: "meeting-notes-gpt4"
+      label: "Meeting Notes Assistant (GPT4)"
+      description: "Generate meeting notes by simply pasting in the transcript from a Teams recording."
+      preset:
+        endpoint: "azureOpenAI"
+        model: "gpt-4-turbo-1106-preview"
+        maxContextTokens: 128000 # Maximum context tokens
+        modelLabel: "Meeting Summarizer"
+        iconURL: "https://example.com/icon.png"
+        greeting: |
+          This assistant creates meeting notes based on transcripts of Teams recordings.
+          To start, simply paste the transcript into the chat box.
+        promptPrefix: |
+          Based on the transcript, create coherent meeting minutes for a business meeting. Include the following sections:
+          - Date and Attendees
+          - Agenda
+          - Minutes
+          - Action Items
+
+          Focus on what items were discussed and/or resolved. List any open action items.
+          The format should be a bulleted list of high level topics in chronological order, and then one or more concise sentences explaining the details.
+          Each high level topic should have at least two sub topics listed, but add as many as necessary to support the high level topic. 
+
+          - Do not start items with the same opening words.
+
+          Take a deep breath and be sure to think step by step.
+        temperature: 0.2
+        max_tokens: 4096 # Maximum output tokens
 ```
 
 ## enforce

--- a/pages/docs/configuration/librechat_yaml/object_structure/model_specs.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/model_specs.mdx
@@ -37,6 +37,8 @@ modelSpecs:
         endpoint: "azureOpenAI"
         model: "gpt-4-turbo-1106-preview"
         maxContextTokens: 128000 # Maximum context tokens
+        max_tokens: 4096 # Maximum output tokens
+        temperature: 0.2
         modelLabel: "Meeting Summarizer"
         greeting: |
           This assistant creates meeting notes based on transcripts of Teams recordings.
@@ -55,8 +57,6 @@ modelSpecs:
           - Do not start items with the same opening words.
 
           Take a deep breath and be sure to think step by step.
-        temperature: 0.2
-        max_tokens: 4096 # Maximum output tokens
 ```
 
 ## enforce

--- a/pages/docs/configuration/librechat_yaml/object_structure/model_specs.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/model_specs.mdx
@@ -166,7 +166,7 @@ preset:
 **Key:**
 <OptionTable
   options={[
-    ['greeting', 'String (optional)', 'A predefined message that is visible in the UI before a new chat is started.', ''],
+    ['greeting', 'String (optional)', 'A predefined message that is visible in the UI before a new chat is started. This is a good way to provide instructions to the user, or to make the interface seem more friendly and accessible.', ''],
   ]}
 />
 
@@ -176,7 +176,7 @@ preset:
 
 ```yaml filename="modelSpecs / list / {spec_item} / preset / greeting"
 preset:
-  greeting: "Hello! How can I assist you today?"
+  greeting: "This assistant creates meeting notes based on transcripts of Teams recordings. To start, simply paste the transcript into the chat box."
 ```
 
 ### promptPrefix

--- a/pages/docs/configuration/librechat_yaml/object_structure/model_specs.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/model_specs.mdx
@@ -31,13 +31,13 @@ modelSpecs:
     - name: "meeting-notes-gpt4"
       label: "Meeting Notes Assistant (GPT4)"
       description: "Generate meeting notes by simply pasting in the transcript from a Teams recording."
+      iconURL: "https://example.com/icon.png"
       preset:
         default: true
         endpoint: "azureOpenAI"
         model: "gpt-4-turbo-1106-preview"
         maxContextTokens: 128000 # Maximum context tokens
         modelLabel: "Meeting Summarizer"
-        iconURL: "https://example.com/icon.png"
         greeting: |
           This assistant creates meeting notes based on transcripts of Teams recordings.
           To start, simply paste the transcript into the chat box.

--- a/pages/docs/configuration/librechat_yaml/object_structure/model_specs.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/model_specs.mdx
@@ -190,11 +190,31 @@ preset:
 
 **Default:** `None`
 
-**Example:**
+**Example 1:**
 
 ```yaml filename="modelSpecs / list / {spec_item} / preset / promptPrefix"
 preset:
   promptPrefix: "As a financial advisor, ..."
+```
+
+**Example 2:**
+
+```yaml filename="modelSpecs / list / {spec_item} / preset / promptPrefix"
+preset:
+  promptPrefix: |
+          Based on the transcript, create coherent meeting minutes for a business meeting. Include the following sections:
+          - Date and Attendees
+          - Agenda
+          - Minutes
+          - Action Items
+
+          Focus on what items were discussed and/or resolved. List any open action items.
+          The format should be a bulleted list of high level topics in chronological order, and then one or more concise sentences explaining the details.
+          Each high level topic should have at least two sub topics listed, but add as many as necessary to support the high level topic. 
+
+          - Do not start items with the same opening words.
+
+          Take a deep breath and be sure to think step by step.
 ```
 
 ### model_options


### PR DESCRIPTION
- Added new, real-world example
- Added `model`
- Additional example for `promptPrefix`
- Updated `greeting`
- Added link to interface page